### PR TITLE
Supress warning on HHVM

### DIFF
--- a/src/Tokenly/CounterpartyTransactionParser/Parser.php
+++ b/src/Tokenly/CounterpartyTransactionParser/Parser.php
@@ -487,7 +487,7 @@ class Parser
     protected static function arc4decrypt($key, $encrypted_text)
     {
         $init_vector = '';
-        return mcrypt_decrypt(MCRYPT_ARCFOUR, $key, $encrypted_text, MCRYPT_MODE_STREAM, $init_vector);
+        return @mcrypt_decrypt(MCRYPT_ARCFOUR, $key, $encrypted_text, MCRYPT_MODE_STREAM, $init_vector);
     }
 
     public static function base58_check_encode($hash160, $address_version) {


### PR DESCRIPTION
on HHVM a warning is thrown that the IV should equal the blocksize, but it works just fine.  
supressing with an `@` sucks, but this fixes the anoying warning.